### PR TITLE
Added event names to output

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -19,6 +19,7 @@ module.exports = function(sourcePath) {
             });
 
             return {
+                event: "coverage",
                 coverageData: coverageData,
                 moduleMap: moduleMap
             };

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -19,7 +19,6 @@ module.exports = function(sourcePath) {
             });
 
             return {
-                event: "coverage",
                 coverageData: coverageData,
                 moduleMap: moduleMap
             };

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -39,11 +39,12 @@ var coverageDir = path.join(".coverage", "instrumented");
 function createLogger(args) {
     var isJsonOutput = args.report === "json";
     var logger = function(op) {
-        return function(msg) {
+        return function(event, msg) {
             var now = "[" + moment().format("hh:mm:ss.SS") + "] ";
 
             if (isJsonOutput) {
                 var message = {
+                    event: event,
                     message: msg,
                     ts: moment()
                 };
@@ -64,13 +65,14 @@ function createLogger(args) {
 
 var modifyTestsPackageJson = (log, args) => () => {
     var testsElmPackageJsonPath = path.join(args.tests, "elm-package.json");
-    log.debug("Modifying " + testsElmPackageJsonPath + "...");
+    log.debug("modifyingTests", "Modifying " + testsElmPackageJsonPath + "...");
     return fs
         .readJson(testsElmPackageJsonPath)
         .then(function(elmPackage) {
             var tmpFile = path.join(".coverage", "elm-package.json.bak");
             return fs.copy(testsElmPackageJsonPath, tmpFile).then(function() {
                 log.info(
+                    "backupComplete",
                     "Wrote original " +
                         testsElmPackageJsonPath +
                         " to " +
@@ -104,12 +106,12 @@ var modifyTestsPackageJson = (log, args) => () => {
             return fs.writeJson(testsElmPackageJsonPath, elmPackage);
         })
         .then(function() {
-            log.debug("Modified " + testsElmPackageJsonPath);
+            log.debug("testModificationComplete", "Modified " + testsElmPackageJsonPath);
         });
 };
 
 var runTests = (log, args) => () => {
-    log.info("Running tests...");
+    log.info("testRunInit", "Running tests...");
     return new Promise(function(resolve, reject) {
         var process = spawn(
             args["elm-test"],
@@ -128,13 +130,13 @@ var runTests = (log, args) => () => {
 
         process.on("exit", function(exitCode) {
             if (exitCode === 0) {
-                log.debug("Ran tests!");
+                log.debug("testRunComplete", "Ran tests!");
                 resolve();
             } else if (args.force) {
-                log.info("Some tests failed. `--force` passed so continuing.");
+                log.info("testFailure", "Some tests failed. `--force` passed so continuing.");
                 resolve();
             } else {
-                log.error("Ruh roh, tests failed.");
+                log.error("testFailure", "Ruh roh, tests failed.");
                 reject(new Error(errStream));
             }
         });
@@ -142,13 +144,13 @@ var runTests = (log, args) => () => {
 };
 
 var cleanup = (log, args) => () => {
-    log.debug("Cleaning up...");
+    log.debug("cleanUp", "Cleaning up...");
     var tmpFile = path.join(".coverage", "elm-package.json.bak");
 
     return fs
         .copy(tmpFile, path.join(args.tests, "elm-package.json"))
         .then(function() {
-            log.info("Restored " + path.join(args.tests, "elm-package.json"));
+            log.info("restoration", "Restored " + path.join(args.tests, "elm-package.json"));
         })
         .catch(function() {});
 };
@@ -187,7 +189,7 @@ var instrumentSources = (log, args) => () => {
             );
         })
         .then(function() {
-            log.info("Instrumenting sources...");
+            log.info("instrumenting", "Instrumenting sources...");
 
             return new Promise(function(resolve, reject) {
                 var process = spawn(elmInstrument, [coverageDir]);
@@ -209,17 +211,18 @@ var instrumentSources = (log, args) => () => {
 };
 
 var generateReport = (log, args) => () => {
-    log.debug("Aggregating info");
+    log.debug("aggregating", "Aggregating info");
     return aggregate(args.path).then(function(data) {
         switch (args.report) {
             case "json":
                 console.log(JSON.stringify(data, null, 0));
                 return Promise.resolve();
             case "human":
-                log.info("Generating report...");
+                log.info("generating", "Generating report...");
                 return analyzer(args.path, data);
             case "codecov":
                 log.info(
+                    "generating",
                     "Writing code coverage to " +
                         path.join(".coverage", "codecov.json")
                 );
@@ -235,10 +238,11 @@ var finishUp = (log, args) => () => {
         if (args.report !== "human") {
             // Do nothing!
         } else if (args.open) {
-            log.info("All done! Opening .coverage/coverage.html");
+            log.info("complete", "All done! Opening .coverage/coverage.html");
             opn(".coverage/coverage.html", { wait: false });
         } else {
             log.info(
+                "complete",
                 "All done! Your coverage is waiting for you in .coverage/coverage.html"
             );
         }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -215,6 +215,7 @@ var generateReport = (log, args) => () => {
     return aggregate(args.path).then(function(data) {
         switch (args.report) {
             case "json":
+                data["event"] = "coverage";
                 console.log(JSON.stringify(data, null, 0));
                 return Promise.resolve();
             case "human":

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -69,6 +69,9 @@ describe("E2E tests", function() {
         ]).spread((actual, expectedJSON) => {
             var expected = {};
 
+            //expected event is "coverage"
+            expected.event = "coverage";
+
             // Ignore runcounts
             expected.coverageData = _.mapValues(
                 expectedJSON.coverageData,


### PR DESCRIPTION
This creates consistency with elm-test and allows consumers of the JSON output to operate more consistently against all events generated by elm-coverage.