### PR TITLE
Restore Windows support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,31 @@
+environment:
+  matrix:
+  - NODE_VERSION: "8"
+  - NODE_VERSION: "4"
+
+init:
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
+
+platform:
+  - x86
+  - x64
+
+
+matrix:
+  fast_finish: true
+
+
+install:
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:NODE_VERSION) $env:Platform
+  - node --version
+  - npm --version
+  - npm install
+  - npm run make
+
+
+test_script:
+  - npm test
+
+
+build: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - NODE_VERSION: "8"
-  - NODE_VERSION: "4"
+  - NODE_VERSION: "LTS"
+  - NODE_VERSION: "6"
 
 platform:
   - x86

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,9 +3,6 @@ environment:
   - NODE_VERSION: "8"
   - NODE_VERSION: "4"
 
-init:
-  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-
 platform:
   - x86
   - x64

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - NODE_VERSION: "LTS"
-  - NODE_VERSION: "6"
+  - NODE_VERSION: "8"
+  - NODE_VERSION: "10"
 
 platform:
   - x86

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,15 +6,12 @@ environment:
 init:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
-
 platform:
   - x86
   - x64
 
-
 matrix:
   fast_finish: true
-
 
 install:
   - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:NODE_VERSION) $env:Platform
@@ -23,9 +20,7 @@ install:
   - npm install
   - npm run make
 
-
 test_script:
   - npm test
-
 
 build: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,6 +18,7 @@ install:
   - node --version
   - npm --version
   - npm install
+  - npm install --global elm
   - npm run make
 
 test_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - "6"
-  - "lts/*"
+  - "8"
+  - "10"
 
 install: npm ci
 before_script: npm run make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: node_js
-node_js: "node"
+node_js:
+  - "6"
+  - "lts/*"
 
 install: npm ci
 before_script: npm run make

--- a/bin/fake-elm
+++ b/bin/fake-elm
@@ -3,79 +3,99 @@
 var yargs = require("yargs");
 var spawn = require("child_process").spawn;
 var fs = require("fs-extra");
+var which = require("which");
+
+var elmBinary = (pathToElmBinary = which.sync("elm"));
 
 yargs
     .command({
         command: "$0",
         desc: "pass through arguments to elm",
         handler: function(args) {
-            spawn("elm", process.argv.slice(2), {stdio: 'inherit'}).on('exit', process.exit);
+            spawn(elmBinary, process.argv.slice(2), { stdio: "inherit" }).on(
+                "exit",
+                process.exit
+            );
         }
     })
     .command({
         command: "make",
-        desc: "run elm make and then inject coverage tracking code into geneated JS output",
+        desc:
+            "run elm make and then inject coverage tracking code into geneated JS output",
         builder: function(yargs) {
-            return yargs
-                .option("output", {describe: "specify the name of the resulting JS file.", type: "string"})
+            return yargs.option("output", {
+                describe: "specify the name of the resulting JS file.",
+                type: "string"
+            });
         },
         handler: function(args) {
-            spawn("elm", process.argv.slice(2), {stdio: 'inherit'}).on('exit', function() {
-                // No output will be produced if compiling a package. However the tests should always end up as an 
-                fs.readFile(args.output, { encoding: 'utf8'} , function(err, data) {
-                    if (err) {
-                        return;
-                    }
-					var pattern = new RegExp(
-						"(^var\\s+author\\$project\\$Coverage\\$track.*$\\s+function\\s+\\()" + // function capture
-						"([a-zA-Z]+)" + // arg1
-						"\\s*,\\s*" +
-						"([a-zA-Z]+)" + // arg2
-						"\\)\\s+{$" + // end of function call
-						""
-						, "gm"
-					);
+            spawn(elmBinary, process.argv.slice(2), { stdio: "inherit" }).on(
+                "exit",
+                function() {
+                    fs.readFile(args.output, { encoding: "utf8" }, function(
+                        err,
+                        data
+                    ) {
+                        if (err) {
+                            return;
+                        }
+                        var pattern = new RegExp(
+                            "(^var\\s+author\\$project\\$Coverage\\$track.*$\\s+function\\s+\\()" + // function capture
+                            "([a-zA-Z]+)" + // arg1
+                            "\\s*,\\s*" +
+                            "([a-zA-Z]+)" + // arg2
+                            "\\)\\s+{$" + // end of function call
+                                "",
+                            "gm"
+                        );
 
-                    if (!data.match(pattern)) {
-                        fs.writeFileSync("foobar.js", data);
-                    }
-                    var matches = data.match(pattern);
-                    if (!matches) {
-                        return;
-                    }
-					matches = pattern.exec(data);
+                        if (!data.match(pattern)) {
+                            fs.writeFileSync("foobar.js", data);
+                        }
+                        var matches = data.match(pattern);
+                        if (!matches) {
+                            return;
+                        }
+                        matches = pattern.exec(data);
 
-                    var replacement =
-                        [ "// INJECTED COVERAGE FIXTURE "
-                        , "var fs = require(\"fs\");"
-                        , "var counters = {};"
-                        , "setTimeout(function() {"
-                        , "    if (typeof app === \"undefined\") {"
-                        , "        throw \"elm-coverage error, failed to find test runner provided by elm-test\";"
-                        , "    }"
-                        , "    app.ports.send.subscribe(function(rawData) {"
-                        , "        var data = JSON.parse(rawData);"
-                        , "        if (data.type === \"FINISHED\") {"
-                        , "            fs.writeFileSync("
-                        , "                \"data-\" + process.pid + \".json\","
-                        , "                JSON.stringify(counters)"
-                        , "            );"
-                        , "        }"
-                        , "    });"
-                        , "});"
-						, ""
-                        , matches[1] + matches[2] + ", " + matches[3] + ") {"
-                        , "        counters[" + matches[2] + "] = counters["+ matches[2] + "] || [];"
-                        , "        counters[" + matches[2] + "].push(" + matches[3] + ");"
-						, ""
+                        var replacement = [
+                            "// INJECTED COVERAGE FIXTURE ",
+                            'var fs = require("fs");',
+                            "var counters = {};",
+                            "setTimeout(function() {",
+                            '    if (typeof app === "undefined") {',
+                            '        throw "elm-coverage error, failed to find test runner provided by elm-test";',
+                            "    }",
+                            "    app.ports.send.subscribe(function(rawData) {",
+                            "        var data = JSON.parse(rawData);",
+                            '        if (data.type === "FINISHED") {',
+                            "            fs.writeFileSync(",
+                            '                "data-" + process.pid + ".json",',
+                            "                JSON.stringify(counters)",
+                            "            );",
+                            "        }",
+                            "    });",
+                            "});",
+                            "",
+                            matches[1] + matches[2] + ", " + matches[3] + ") {",
+                            "        counters[" +
+                                matches[2] +
+                                "] = counters[" +
+                                matches[2] +
+                                "] || [];",
+                            "        counters[" +
+                                matches[2] +
+                                "].push(" +
+                                matches[3] +
+                                ");",
+                            ""
                         ].join("\n");
-        
-                    var result = data.replace(pattern, replacement);
-                    fs.writeFileSync(args.output, result);
-                    process.exit();
-                })
-            
-            });
+
+                        var result = data.replace(pattern, replacement);
+                        fs.writeFileSync(args.output, result);
+                        process.exit();
+                    });
+                }
+            );
         }
-    })
-    .argv
+    }).argv;

--- a/bin/fake-elm.cmd
+++ b/bin/fake-elm.cmd
@@ -1,0 +1,3 @@
+@SETLOCAL
+@SET PATHEXT=%PATHEXT:;.JS;=;%
+node  "%~dp0\fake-elm" %*


### PR DESCRIPTION
The trick is using a `fake-elm.cmd` wrapper.

When a binary is invoked on windows without an extension, it goes and checks its `PATHEXT` for valid extensions, then looks for files with a name + extension from the `PATHEXT` list. If it finds such a thing, that file gets invoked. `which` on Windows uses the same magic.

So, by adding such a file with an appropriate extension, containing some good old fashioned batch file that just spawns our actual wrapper script, we can make everything work out.

It's a little painful to wrap a wrapper, but hey, that's life.

Closes #14 