### PR TITLE
fix: remove incorrect comment about absolute path support in elm-test

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -34,10 +34,7 @@ module.exports.generateOnly = function(args) {
 
 var elmInstrument = path.join(__dirname, "..", "bin", "elm-instrument");
 var coverageDir = path.join(".coverage", "instrumented");
-// elm-test 0.19.0-rev4 does not support absolute paths in
-// elm.json. Therefore we need to compute the new relative
-// paths from the coverage directory
-var fakeElmBinary = path.relative(coverageDir, path.resolve(path.join(__dirname, "..", "bin", "fake-elm")));
+var fakeElmBinary = path.resolve(path.join(__dirname, "..", "bin", "fake-elm"));
 
 function createLogger(args) {
     var isJsonOutput = args.report === "json";


### PR DESCRIPTION
fixes #16 