### PR TITLE
Run elm-coverage when elm is not globally installed

### DIFF
--- a/bin/fake-elm
+++ b/bin/fake-elm
@@ -3,9 +3,38 @@
 var yargs = require("yargs");
 var spawn = require("child_process").spawn;
 var fs = require("fs-extra");
+var path = require("path");
 var which = require("which");
 
-var elmBinary = (pathToElmBinary = which.sync("elm"));
+function findElmBinary() {
+    var found, errors = []
+    function find(name) {
+        try {
+            return which.sync(name);
+        } catch (ex) {
+            errors.push("which did not find '" + name + "'");
+        }
+    }
+
+    const elmPaths = [ 
+        // elm is installed as a dependency of elm-coverage
+        path.join(__dirname, "../node_modules/elm/unpacked_bin/elm"),
+        // elm and elm-coverage are both local dependencies of another project
+        path.join(__dirname, "../../elm/unpacked_bin/elm"),
+        // use a global elm installation
+        "elm"
+    ];
+
+    for (const elm of elmPaths) {
+        found = find(elm);
+        if (found) {
+            return found;
+        }
+    }
+
+    throw new Error('Could not find an elm executable');
+}
+var elmBinary = findElmBinary();
 
 yargs
     .command({


### PR DESCRIPTION
Hello @zwilias, 
I wanted to run elm-coverage in our CI system without a global installation of elm, so I made the attached changes to get it to run.

This change should find the elm executable if both elm and elm-coverage were specified as node dependencies or if elm was installed as a dependency of elm-coverage (e.g. when cloning this repository).

Are you interested in such a change or do you maybe have a better idea to specify another elm compiler for fake-elm?

Regards,
marc