### PR TITLE
Change detection of `data-<pid>.json` files

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -70,10 +70,7 @@ function addCoverage(info, coverage) {
 }
 
 function isCoverageDataFile(filePath) {
-    if (filePath.endsWith("elm.json") || filePath.endsWith("info.json")) {
-        return false;
-    }
-    return filePath.endsWith(".json");
+    return /^data-\d+.json$/.test(filePath);
 }
 
 function toPath(sourcePath, moduleName) {


### PR DESCRIPTION
Hello @zwilias,

this is a minor change to detect the coverage data JSON files. The function could also be directly replaced with the RegEx test. 

It seemed more resilient to me for future changes in the node test runner.

Cheers,
marc