### PR TITLE
Support custom tests location

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -73,9 +73,6 @@ var setupTests = (log, args) => () => {
                 "modifyingTests",
                 "Generating elm.json for coverage at " + tmpElmJson + "..."
             );
-            var covSrc = path.resolve(path.join(coverageDir, args.path));
-            var originalPath = path.resolve(args.path);
-
             elmPackage["name"] = "author/project";
 
             return elmPackage;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -85,7 +85,7 @@ var setupTests = (log, args) => () => {
             return fs.writeJson(tmpElmJson, elmPackage);
         })
         .then(function() {
-            var generatedTestsDir = path.join(coverageDir, "tests");
+            var generatedTestsDir = path.join(coverageDir, args.tests);
             log.debug(
                 "copyTests",
                 "Copying tests from " + args.tests + " to " + generatedTestsDir

--- a/tests/data/custom-locations/.gitignore
+++ b/tests/data/custom-locations/.gitignore
@@ -1,0 +1,2 @@
+.coverage
+elm-stuff/

--- a/tests/data/custom-locations/client/src/Main.elm
+++ b/tests/data/custom-locations/client/src/Main.elm
@@ -1,0 +1,8 @@
+module Main exposing (foo)
+
+import Simple
+
+
+foo : String
+foo =
+    "hello " ++ Simple.foo

--- a/tests/data/custom-locations/client/src/Simple.elm
+++ b/tests/data/custom-locations/client/src/Simple.elm
@@ -1,0 +1,5 @@
+module Simple exposing (foo)
+
+foo : String
+foo =
+    "world"

--- a/tests/data/custom-locations/client/tests/Example.elm
+++ b/tests/data/custom-locations/client/tests/Example.elm
@@ -1,0 +1,13 @@
+module Example exposing (..)
+
+import Expect
+import Main
+import Test exposing (..)
+
+
+suite : Test
+suite =
+    test "A simple, succesfull test" <|
+        \_ ->
+            Main.foo
+                |> Expect.equal "hello world"

--- a/tests/data/custom-locations/elm.json
+++ b/tests/data/custom-locations/elm.json
@@ -1,0 +1,29 @@
+{
+    "type": "application",
+    "source-directories": [
+        "client/src",
+        "client/tests"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0"
+        },
+        "indirect": {
+            "elm/json": "1.1.3",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
+        }
+    },
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "1.2.2"
+        },
+        "indirect": {
+            "elm/random": "1.0.0"
+        }
+    }
+}

--- a/tests/data/custom-locations/expected.json
+++ b/tests/data/custom-locations/expected.json
@@ -1,0 +1,41 @@
+{
+  "coverageData": {
+    "Simple": [
+      {
+        "type": "declaration",
+        "name": "foo",
+        "complexity": 1,
+        "from": {
+          "line": 4,
+          "column": 1
+        },
+        "to": {
+          "line": 5,
+          "column": 12
+        },
+        "count": 8
+      }
+    ],
+    "Main": [
+      {
+        "type": "declaration",
+        "name": "foo",
+        "complexity": 1,
+        "from": {
+          "line": 7,
+          "column": 1
+        },
+        "to": {
+          "line": 8,
+          "column": 27
+        },
+        "count": 8
+      }
+    ]
+  },
+  "moduleMap": {
+    "Simple": "client/src/Simple.elm",
+    "Main": "client/src/Main.elm"
+  },
+  "event": "coverage"
+}

--- a/tests/data/simple/.gitignore
+++ b/tests/data/simple/.gitignore
@@ -1,1 +1,2 @@
+.coverage
 elm-stuff/

--- a/tests/data/simple/elm.json
+++ b/tests/data/simple/elm.json
@@ -6,20 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/core": "1.0.4"
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0"
         },
-        "indirect": {}
+        "indirect": {
+            "elm/json": "1.1.3",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
+        }
     },
     "test-dependencies": {
         "direct": {
             "elm-explorations/test": "1.2.2"
         },
         "indirect": {
-            "elm/html": "1.0.0",
-            "elm/json": "1.1.3",
-            "elm/random": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/random": "1.0.0"
         }
     }
 }

--- a/tests/data/simple/tests/Example.elm
+++ b/tests/data/simple/tests/Example.elm
@@ -1,6 +1,6 @@
 module Example exposing (..)
 
-import Expect exposing (Expectation)
+import Expect
 import Main
 import Test exposing (..)
 

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -37,69 +37,82 @@ describe("Sanity test", () => {
     });
 });
 
+var projects = [
+    { 
+        path: "simple", 
+        args: [],
+        generateArgs: [],
+    },
+];
+
 describe("E2E tests", function() {
     this.timeout(Infinity);
-    it("Should run succesfully", done => {
-        var process = spawn.spawn(elmCoverage, {
-            cwd: path.join("tests", "data", "simple")
-        });
 
-        process.stderr.on("data", data => {
-            console.error(data.toString());
-        });
+    projects.forEach((project) => {
+        describe(project.path, () => {
+            it("Should run succesfully", done => {
+                var process = spawn.spawn(elmCoverage, project.args, {
+                    cwd: path.join("tests", "data", project.path)
+                });
 
-        process.on("exit", exitCode => {
-            assert.equal(exitCode, 0, "Expected to finish succesfully");
-            done();
+                process.stderr.on("data", data => {
+                    console.error(data.toString());
+                });
+
+                process.on("exit", exitCode => {
+                    assert.equal(exitCode, 0, "Expected to finish succesfully");
+                    done();
+                });
+            });
+
+            it("Should generate schema-validated JSON", () =>
+                Promise.all([
+                    fs.readJSON(require.resolve("../docs/elm-coverage.json")),
+                    generateJSON(project)
+                ]).spread((json, schema) => {
+                    expect(json).to.be.jsonSchema(schema);
+                }));
+
+            it("Should generate JSON that matches the pregenerated one, modulus runcount", () =>
+                Promise.all([
+                    generateJSON(project),
+                    fs.readJSON(require.resolve("./data/" + project.path + "/expected.json"))
+                ]).spread((actual, expectedJSON) => {
+                    var expected = {};
+
+                    //expected event is "coverage"
+                    expected.event = "coverage";
+
+                    // Ignore runcounts
+                    expected.coverageData = _.mapValues(
+                        expectedJSON.coverageData,
+                        moduleData =>
+                            _.map(moduleData, coverage =>
+                                Object.assign({}, coverage, {
+                                    count: _.isInteger
+                                })
+                            )
+                    );
+
+                    // System agnostic paths
+                    expected.moduleMap = _.mapValues(
+                        expectedJSON.moduleMap,
+                        modulePath => _.partial(_.matchesPath, modulePath, _)
+                    );
+
+                    expect(actual).to.matchPattern(expected);
+                }));
         });
     });
-
-    it("Should generate schema-validated JSON", () =>
-        Promise.all([
-            fs.readJSON(require.resolve("../docs/elm-coverage.json")),
-            generateJSON()
-        ]).spread((json, schema) => {
-            expect(json).to.be.jsonSchema(schema);
-        }));
-
-    it("Should generate JSON that matches the pregenerated one, modulus runcount", () =>
-        Promise.all([
-            generateJSON(),
-            fs.readJSON(require.resolve("./data/simple/expected.json"))
-        ]).spread((actual, expectedJSON) => {
-            var expected = {};
-
-            //expected event is "coverage"
-            expected.event = "coverage";
-
-            // Ignore runcounts
-            expected.coverageData = _.mapValues(
-                expectedJSON.coverageData,
-                moduleData =>
-                    _.map(moduleData, coverage =>
-                        Object.assign({}, coverage, {
-                            count: _.isInteger
-                        })
-                    )
-            );
-
-            // System agnostic paths
-            expected.moduleMap = _.mapValues(
-                expectedJSON.moduleMap,
-                modulePath => _.partial(_.matchesPath, modulePath, _)
-            );
-
-            expect(actual).to.matchPattern(expected);
-        }));
 });
 
-function generateJSON() {
+function generateJSON(project) {
     return new Promise((resolve, reject) => {
         var process = spawn.spawn(
             elmCoverage,
-            ["generate", "--report", "json"],
+            ["generate", ...project.generateArgs, "--report", "json"],
             {
-                cwd: path.join("tests", "data", "simple")
+                cwd: path.join("tests", "data", project.path)
             }
         );
 

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -43,6 +43,11 @@ var projects = [
         args: [],
         generateArgs: [],
     },
+    { 
+        path: "custom-locations", 
+        args: ["client/src", "--tests", "client/tests"],
+        generateArgs: ["client/src"],
+    }
 ];
 
 describe("E2E tests", function() {


### PR DESCRIPTION
The docs indicate that a custom tests location is supported using the `--tests` arg, but as shown in #44, this doesn't actually work.

Resolves #44

The fix was a single line change, but there was a bit of work to do to add a test project to show the issue. I've split the commits into semantic chunks that should tell a pretty clear story:

1. **Fix local `elm make` in test project** — when I was looking to add a new test project I started by trying to build and run the tests in the existing one. `elm make` failed there with some concerns about elm.json. Even though `elm-test` worked fine, I figured it was worth improving the integrity of the test project.

2. **Ignore generated coverage files** — running `elm-coverage` in the test project generated coverage files that were not ignored.

3. **Support multiple test projects** — the existing tests had `simple` hardcoded throughout, so to avoid duplicating them all, I refactored them into a loop that could be extended with additional test projects.

4. **Add (failing) tests for custom tests location** — this is a copy of the simple case, adjusted to showcase the issue outlined in #44. I committed this alone so it would be easy to verify the failure and the coming fix.

5. **Fix issue with custom tests location** — the one-line fix: wherever the tests were before, they should still be in the instrumented directory so that the `elm.json` file remains accurate.

6. **Remove unused lines** — tiny cleanup of unused lines that distracted me when I was reading lib/runner.js.